### PR TITLE
Feature/tophits averages

### DIFF
--- a/server/config/cron/checkHit.js
+++ b/server/config/cron/checkHit.js
@@ -26,7 +26,8 @@ const checkHit = (company, newTrend) => {
       if (lastTrend.standardDeviation * 2 > percentage) {
         percentage = lastTrend.standardDeviation * 2;
       }
-
+      // only generates a hit if the previous highest trend day's average goes down
+      // by 15% or 2*standard deviation, whichever is highest.
       const minimumHitReq = topAvg.avg - percentage;
       const compAvg = newTrend[`day${topAvg.day - daysDiff}avg`];
       if (compAvg < minimumHitReq) {

--- a/server/config/cron/checkHit.js
+++ b/server/config/cron/checkHit.js
@@ -10,27 +10,27 @@ const checkHit = (company, newTrend) => {
     );
     if (daysDiff < 6) {
       // this will exclude days which lastTrend and newTrend don't have in common
-      let lastTrendMaxes = new Map();
+      let lastTrendAvgs = new Map();
       for (let i = 6; i > daysDiff; i--) {
-        lastTrendMaxes.set(i, lastTrend[`day${i}max`]);
+        lastTrendAvgs.set(i, lastTrend[`day${i}avg`]);
       }
-      const lastMax = { max: 0, day: 0 };
-      lastTrendMaxes.forEach((max, key) => {
-        if (lastMax.max < max) {
-          lastMax.max = max;
-          lastMax.day = key;
+      const topAvg = { avg: 0, day: 0 };
+      lastTrendAvgs.forEach((avg, key) => {
+        if (topAvg.avg < avg) {
+          topAvg.avg = avg;
+          topAvg.day = key;
         }
       });
-      const diff = lastMax.max - newTrend[`day${lastMax.day - daysDiff}max`];
 
-      // a hit will only be generated if the previous high (that they have in common) changes by
-      // more than double the standard deviation or 15, whichever is greater.
-      let divisor = 15;
-      if (lastTrend.standardDeviation * 2 > divisor) {
-        divisor = lastTrend.standardDeviation * 2;
+      let percentage = 15;
+      if (lastTrend.standardDeviation * 2 > percentage) {
+        percentage = lastTrend.standardDeviation * 2;
       }
-      const rating = (diff / divisor).toFixed(2);
-      if (rating > 1) {
+
+      const minimumHitReq = topAvg.avg - percentage;
+      const compAvg = newTrend[`day${topAvg.day - daysDiff}avg`];
+      if (compAvg < minimumHitReq) {
+        const rating = minimumHitReq / (compAvg < 1 ? 1 : compAvg);
         db.top_hits.create({
           CompanyId: company.dataValues.id,
           indicator: rating

--- a/server/config/cron/index.js
+++ b/server/config/cron/index.js
@@ -14,7 +14,7 @@ const standardDev = function(array) {
 const createTrend = async function(date = new Date()) {
   try {
     let midnight = new Date();
-    midnight.setDate(dayOfMonth - 1).setUTCHours(0, 0, 0, 0);
+    midnight.setUTCHours(0, 0, 0, 0);
     const company = await db.Company.findOne({
       include: [db.Trend],
       // Op.lte should be less than or equal to

--- a/server/config/cron/index.js
+++ b/server/config/cron/index.js
@@ -13,11 +13,12 @@ const standardDev = function(array) {
 
 const createTrend = async function(date = new Date()) {
   try {
-    const yesterday = new Date(date - 24 * 60 * 60 * 1000);
+    let midnight = new Date();
+    midnight.setDate(dayOfMonth - 1).setUTCHours(0, 0, 0, 0);
     const company = await db.Company.findOne({
       include: [db.Trend],
       // Op.lte should be less than or equal to
-      where: { checkedAt: { [Op.lte]: yesterday } }
+      where: { checkedAt: { [Op.lte]: midnight } }
     });
 
     if (company) {

--- a/server/config/cron/searchTrends.js
+++ b/server/config/cron/searchTrends.js
@@ -4,7 +4,10 @@ const googleTrends = require('google-trends-api');
 const TIMEZONE = -18;
 
 const searchTrends = function(input, date) {
-  const weekAgo = new Date(date - 6 * 24 * 60 * 60 * 1000);
+  let today = new Date(date);
+  let weekAgo = new Date(date - 6 * 24 * 60 * 60 * 1000);
+  today.setUTCHours(0, 0, 0, 0);
+  weekAgo.setUTCHours(0, 0, 0, 0);
   return googleTrends.interestOverTime({
     keyword: [input],
     startTime: weekAgo,


### PR DESCRIPTION
Uses averages instead of daily maximums to generate top hits, changes all cron job dates to look at midnight UTC for more consistent data.